### PR TITLE
Verify x509 certificate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,6 +46,15 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cc"
+version = "1.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -180,6 +195,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3ea1ec5f8307826a5b71094dd91fc04d4ae75d5709b20ad351c7fb4815c86ec"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +341,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "openssl"
+version = "0.10.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "p384"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,6 +437,12 @@ dependencies = [
  "der 0.7.9",
  "spki 0.7.3",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "ppv-lite86"
@@ -434,6 +514,7 @@ name = "remote-attestation-verifier"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "openssl",
  "p384",
  "rsa",
  "serde_cbor",
@@ -525,6 +606,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,6 +681,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ p384 = { version = "0.13.0", default-features = false, features = [
     "pkcs8",
     "sha384",
 ] }
+openssl = "0.10.66"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,12 +89,12 @@ pub fn verify(
 
     let x509_signature = Signature::from_slice(&x509_signature).expect("Invalid x509 signature");
 
-    //TODO: convert certificate to bytes
-    let mut cert_vec = vec![];
+    //NOTE: certificate is in DER format
+    let mut sig_structure_x509 = vec![];
     cert.tbs_certificate
-        .encode_to_vec(&mut cert_vec)
+        .encode_to_vec(&mut sig_structure_x509)
         .expect("cert to der failed");
-    println!("sig_structure_x509: {:?}", cert_vec);
+    println!("sig_structure_x509: {:?}", sig_structure_x509);
 
     // let mut sig_structure_x509_with_prefix = vec![48, 130, 2, 123];
     // sig_structure_x509_with_prefix.extend_from_slice(&sig_structure_x509);
@@ -102,7 +102,7 @@ pub fn verify(
 
     //BUG:  verify fails here, one of 3 values must be wrong
     issuer_public_key
-        .verify(&cert_vec, &x509_signature)
+        .verify(&sig_structure_x509, &x509_signature)
         .expect("verify x509 cert failed");
 
     //////////////////////////////////////////////////////////////////////////////
@@ -113,23 +113,21 @@ pub fn verify(
     let x509_cert =
         openssl::x509::X509::from_der(_certificate).expect("Failed to parse certificate");
 
-    println!("subject: {:?}", x509_cert.subject_name());
-    println!("issuer: {:?}", x509_cert.issuer_name());
+    //println!("subject: {:?}", x509_cert.subject_name());
+    //println!("issuer: {:?}", x509_cert.issuer_name());
 
     let tbs_cert = x509_cert
         .to_der()
         .expect("Failed to get TBS certificate raw bytes");
 
     let pub_key = x509_cert.public_key().expect("Failed to get public key");
-    println!("subject public key: {:?}", pub_key);
+    //println!("subject public key: {:?}", pub_key);
     println!("x509 signature: {:?}", x509_cert.signature().as_slice());
     println!("sig_structure_x509: {:?}", tbs_cert);
 
     ///// get public key from issuer_cert
     let issuer_cert =
         openssl::x509::X509::from_der(&issuer_der).expect("Failed to parse issuer PEM");
-    let pub_key = issuer_cert.public_key().expect("Failed to get public key");
-    println!("issuer public key: {:?}", pub_key);
 
     use base64::encode;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,12 +33,12 @@ pub fn verify(
     _payload: &[u8],
     _certificate: &[u8],
 ) -> Result<(), p384::ecdsa::Error> {
-    //@ok parse public key, convert from der to sec1 format
+    //OK: parse public key, convert from der to sec1 format
     let cert = x509_cert::Certificate::from_der(_certificate).expect("decode x509 cert failed");
 
     //////////////////////////////////////////////////////////////////////////////
     //1. verify x509 cert signature using x509_cert crate
-    //@ok algorithm is ECDSA using SHA384
+    //OK: algorithm is ECDSA using SHA384
     // println!("signature_algorithm: {:?}", cert.signature_algorithm);
     //println!("subject_public_key_info: {:?}", cert.tbs_certificate.issuer);
     //TODO: next step: extract issuer signature cabundle object iof hardcoded
@@ -62,13 +62,13 @@ pub fn verify(
     // println!("cert name {:?}", cert.tbs_certificate.subject.to_string());
     // println!("cert algorithm: {:?}", cert.signature_algorithm);
 
-    //@test print to PEM for testing in web decoder
+    //TEST: print to PEM for testing in web decoder
     let cert_base64 = encode(&issuer_der);
     println!(
         "-----BEGIN CERTIFICATE-----\n{}\n-----END CERTIFICATE-----",
         cert_base64
     );
-    //@ok
+    //OK:
     let issuer_public_key = &issuer_public_key[issuer_public_key.len() - 97..];
 
     let issuer_public_key =
@@ -144,13 +144,13 @@ pub fn verify(
     let public_key = &public_key[public_key.len() - 97..];
     //println!("cert public key {:?}", public_key);
 
-    //@ok public key valid
+    //OK: public key valid
     let verifying_key = VerifyingKey::from_sec1_bytes(&public_key).expect("Invalid public key");
 
     // Create a Signature object from the raw signature bytes
     let signature = Signature::from_slice(_signature).expect("Invalid signature");
 
-    //@ok construct cosign structure
+    //OK: construct cosign structure
     const HEADER: [u8; 13] = [132, 106, 83, 105, 103, 110, 97, 116, 117, 114, 101, 49, 68];
     let protected = _protected;
 
@@ -171,7 +171,7 @@ pub fn verify(
 
     //println!("sign_structure: {:?}", sign_structure);
     //println!("pcrs: {:?}", document.pcrs);
-    //@ok
+    //OK:
     // Verify the signature
     verifying_key.verify(&sign_structure, &signature)
 }
@@ -501,7 +501,7 @@ mod tests {
 
     // #[test]
     // fn test_std() {
-    //     //@ok parse CBOR doc
+    //     //OK: parse CBOR doc
     //     //@note from url
     //     // let attestation_verifier = AttestationVerifier::new(None, None);
     //     // let nonce = "0000000000000000000000000000000000000001";
@@ -525,7 +525,7 @@ mod tests {
     //     // Step 2. Exract the attestation document from the COSE_Sign1 structure
     //     let document =
     //         parse_payload(&payload).expect("AttestationVerifier::authenticate failed");
-    //     //@ok parse public key, convert from der to sec1 format
+    //     //OK: parse public key, convert from der to sec1 format
     //     let cert = x509_cert::Certificate::from_der(&document.certificate).unwrap();
     //     let public_key = cert
     //         .tbs_certificate
@@ -536,15 +536,15 @@ mod tests {
     //     //sec1 doesnt comprise der headers
     //     let public_key = &public_key[public_key.len() - 97..];
     //     //println!("public key sec1: {:?}", hex::encode(public_key));
-    //     //@ok public key valid
+    //     //OK: public key valid
     //     let verifying_key =
     //         VerifyingKey::from_sec1_bytes(&public_key).expect("Invalid public key");
-    //     //@ok signature valid
+    //     //OK: signature valid
     //     //println!("signature: {:?}", _signature);
     //     //let signature = Signature::from_bytes(&signature.).expect("Invalid signature");
     //     // Create a Signature object from the raw signature bytes
     //     let signature = Signature::from_slice(&_signature).expect("Invalid signature");
-    //     //@ok parse sig_bytes from doc
+    //     //OK: parse sig_bytes from doc
     //     //correspond to Signature1D
     //     let header = [132, 106, 83, 105, 103, 110, 97, 116, 117, 114, 101, 49, 68];
     //     let protected = _protected;
@@ -559,7 +559,7 @@ mod tests {
     //     ]
     //     .concat();
     //     //println!("pcrs: {:?}", document.pcrs);
-    //     //@ok
+    //     //OK:
     //     // Verify the signature
     //     verifying_key
     //         .verify(&sign_structure, &signature)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub struct AttestationDocument {
     pub signature: [u8; 96],
     pub payload: [u8; 4447],
     pub certificate: [u8; 640],
-    pub ca_bundle: [u8; 640],
+    pub ca_bundle: [u8; 2749],
 }
 
 pub fn verify(
@@ -218,21 +218,20 @@ pub fn parse_cbor_document(document: &[u8]) -> Result<AttestationDocument, ()> {
         _ => panic!("Failed to decode CBOR payload:{:?}", payload),
     };
 
-    let certificate = payload
-        .get(&serde_cbor::Value::Text("certificate".try_into().unwrap()))
-        .expect("certificate not found");
-
     let ca_bundle = payload
         .get(&serde_cbor::Value::Text("cabundle".try_into().unwrap()))
         .expect("ca_bundle not found");
 
-    let ca_bundle_bytes: [u8; 2739] = serde_cbor::to_vec(&ca_bundle)
+    let ca_bundle_bytes: [u8; 2752] = serde_cbor::to_vec(&ca_bundle)
         .expect("failed to parse ca_bundle")
         .try_into()
         .expect("error slice ca_bundle");
 
     println!("length of ca_bundle: {:?}", ca_bundle_bytes.len());
 
+    let certificate = payload
+        .get(&serde_cbor::Value::Text("certificate".try_into().unwrap()))
+        .expect("certificate not found");
     //println!("certificate: {:?}", certificate);
 
     let certiricate_bytes: [u8; 643] = serde_cbor::to_vec(&certificate)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,8 @@ pub fn verify(
     //@ok algorithm is ECDSA using SHA384
     // println!("signature_algorithm: {:?}", cert.signature_algorithm);
     //println!("subject_public_key_info: {:?}", cert.tbs_certificate.issuer);
-    //@todo next step: extract issuer signature cabundle object iof hardcoded
-    //@todo panic if algorithm is not expected
+    //TODO: next step: extract issuer signature cabundle object iof hardcoded
+    //TODO: panic if algorithm is not expected
 
     let issuer_pem = "MIICvzCCAkSgAwIBAgIUXfCzGrCNSNDTS+L1DQQA9CBMKNwwCgYIKoZIzj0EAwMwgYkxPDA6BgNVBAMMM2Y3NWZiMzQ0NzZhOTJhODcuem9uYWwudXMtZWFzdC0xLmF3cy5uaXRyby1lbmNsYXZlczEMMAoGA1UECwwDQVdTMQ8wDQYDVQQKDAZBbWF6b24xCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJXQTEQMA4GA1UEBwwHU2VhdHRsZTAeFw0yNDA5MTMxNDIzNTBaFw0yNDA5MTQxNDIzNTBaMIGOMQswCQYDVQQGEwJVUzETMBEGA1UECAwKV2FzaGluZ3RvbjEQMA4GA1UEBwwHU2VhdHRsZTEPMA0GA1UECgwGQW1hem9uMQwwCgYDVQQLDANBV1MxOTA3BgNVBAMMMGktMGJiZjFiZmUyMzJiOGMyY2UudXMtZWFzdC0xLmF3cy5uaXRyby1lbmNsYXZlczB2MBAGByqGSM49AgEGBSuBBAAiA2IABF7SGcHdkRbzl/tGMXHBgJ88sy+HTekW+lomScVSEXYB1giAC6eQgElex/q78JTxuj/k7BV83GfjKE5BS5Bdlohfb3b/yA52MLQubQGAYLSZhBGZmRBaEleTF6r0381CgqNmMGQwEgYDVR0TAQH/BAgwBgEB/wIBADAOBgNVHQ8BAf8EBAMCAgQwHQYDVR0OBBYEFBvZFAgI1uf1KLtxVdsv0Zeh+HFMMB8GA1UdIwQYMBaAFFRGyCn8tZshs/IN+qolNuLZ48fmMAoGCCqGSM49BAMDA2kAMGYCMQDWFeTovh3hlMUu+/nEXCCTKs/0NftxY2s+BXSNFUki8V+LAYNeARuv2FpWHIWR9EECMQCNqJQe507gy1zFEy6loraps1Ohbz9rVETmbRvqekvcYb0KCq9uJMeKaWzgnWWD0wI=";
     let issuer_der = STANDARD.decode(issuer_pem).expect("Failed to decode PEM");
@@ -75,7 +75,7 @@ pub fn verify(
         VerifyingKey::from_sec1_bytes(&issuer_public_key).expect("Invalid public key");
 
     println!("issuer public key sec1 {:?}", issuer_public_key);
-    //@todo should be issuer sig & issuer sig_structure
+    //TODO: should be issuer sig & issuer sig_structure
     let x509_signature = cert.signature.raw_bytes();
 
     //remove DER header
@@ -87,7 +87,7 @@ pub fn verify(
 
     let x509_signature = Signature::from_slice(&x509_signature).expect("Invalid x509 signature");
 
-    //@todo convert certificate to bytes
+    //TODO: convert certificate to bytes
     let mut cert_vec = vec![];
     cert.tbs_certificate
         .encode_to_vec(&mut cert_vec)
@@ -98,13 +98,13 @@ pub fn verify(
     // sig_structure_x509_with_prefix.extend_from_slice(&sig_structure_x509);
     // let sig_structure_x509 = sig_structure_x509_with_prefix;
 
-    //@bug verify fails here
+    //BUG:  verify fails here
     issuer_public_key
         .verify(&cert_vec, &x509_signature)
         .expect("verify x509 cert failed");
 
     //////////////////////////////////////////////////////////////////////////////
-    /////@test using OPENSSL to see if we get the same parameters
+    /////TEST: using OPENSSL to see if we get the same parameters
 
     ///// get signature & sig_structure from cert
     println!("---------------------------------------\n using openssl");
@@ -176,7 +176,7 @@ pub fn verify(
     verifying_key.verify(&sign_structure, &signature)
 }
 
-//@bug doesn't work consistenty because no_std expect fixed size arrays but
+//BUG: doesn't work consistenty because no_std expect fixed size arrays but
 // remote attestation is of variable size
 pub fn parse_cbor_document(document: &[u8]) -> Result<AttestationDocument, ()> {
     use serde_cbor;
@@ -548,7 +548,7 @@ mod tests {
     //     //correspond to Signature1D
     //     let header = [132, 106, 83, 105, 103, 110, 97, 116, 117, 114, 101, 49, 68];
     //     let protected = _protected;
-    //     //@todo sometimes last byte is 96 sometimes 95, need to figure out why
+    //     //TODO: sometimes last byte is 96 sometimes 95, need to figure out why
     //     let filler = [64, 89, 17, 96];
     //     let payload = payload;
     //     let sign_structure = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,9 +39,7 @@ pub fn verify(
     let cert = x509_cert::Certificate::from_der(_certificate).expect("decode x509 cert failed");
     let bundle_certs = extract_certificates_from_der(_ca_bundle);
     println!("number of certs in bundle: {:?}", bundle_certs.len());
-    for cert in bundle_certs {
-        println!("ca bundle issuer: {:?}", cert.signature_algorithm);
-    }
+    let issuer_cert = bundle_certs.get(0).expect("issuer cert not found");
 
     //////////////////////////////////////////////////////////////////////////////
     //1. verify x509 cert signature using x509_cert crate
@@ -53,10 +51,10 @@ pub fn verify(
 
     //NOTE: issuer cert is extracted from the cabundle (check main branch to find the code to extract the certs from cabundle object)
     //TODO: next step: extract issuer signature cabundle object iof hardcoded
-    let issuer_pem = "MIICvzCCAkSgAwIBAgIUXfCzGrCNSNDTS+L1DQQA9CBMKNwwCgYIKoZIzj0EAwMwgYkxPDA6BgNVBAMMM2Y3NWZiMzQ0NzZhOTJhODcuem9uYWwudXMtZWFzdC0xLmF3cy5uaXRyby1lbmNsYXZlczEMMAoGA1UECwwDQVdTMQ8wDQYDVQQKDAZBbWF6b24xCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJXQTEQMA4GA1UEBwwHU2VhdHRsZTAeFw0yNDA5MTMxNDIzNTBaFw0yNDA5MTQxNDIzNTBaMIGOMQswCQYDVQQGEwJVUzETMBEGA1UECAwKV2FzaGluZ3RvbjEQMA4GA1UEBwwHU2VhdHRsZTEPMA0GA1UECgwGQW1hem9uMQwwCgYDVQQLDANBV1MxOTA3BgNVBAMMMGktMGJiZjFiZmUyMzJiOGMyY2UudXMtZWFzdC0xLmF3cy5uaXRyby1lbmNsYXZlczB2MBAGByqGSM49AgEGBSuBBAAiA2IABF7SGcHdkRbzl/tGMXHBgJ88sy+HTekW+lomScVSEXYB1giAC6eQgElex/q78JTxuj/k7BV83GfjKE5BS5Bdlohfb3b/yA52MLQubQGAYLSZhBGZmRBaEleTF6r0381CgqNmMGQwEgYDVR0TAQH/BAgwBgEB/wIBADAOBgNVHQ8BAf8EBAMCAgQwHQYDVR0OBBYEFBvZFAgI1uf1KLtxVdsv0Zeh+HFMMB8GA1UdIwQYMBaAFFRGyCn8tZshs/IN+qolNuLZ48fmMAoGCCqGSM49BAMDA2kAMGYCMQDWFeTovh3hlMUu+/nEXCCTKs/0NftxY2s+BXSNFUki8V+LAYNeARuv2FpWHIWR9EECMQCNqJQe507gy1zFEy6loraps1Ohbz9rVETmbRvqekvcYb0KCq9uJMeKaWzgnWWD0wI=";
-    let issuer_der = STANDARD.decode(issuer_pem).expect("Failed to decode PEM");
-    let issuer_cert =
-        x509_cert::Certificate::from_der(&issuer_der).expect("decode x509 cert failed");
+    // let issuer_pem = "MIICvzCCAkSgAwIBAgIUXfCzGrCNSNDTS+L1DQQA9CBMKNwwCgYIKoZIzj0EAwMwgYkxPDA6BgNVBAMMM2Y3NWZiMzQ0NzZhOTJhODcuem9uYWwudXMtZWFzdC0xLmF3cy5uaXRyby1lbmNsYXZlczEMMAoGA1UECwwDQVdTMQ8wDQYDVQQKDAZBbWF6b24xCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJXQTEQMA4GA1UEBwwHU2VhdHRsZTAeFw0yNDA5MTMxNDIzNTBaFw0yNDA5MTQxNDIzNTBaMIGOMQswCQYDVQQGEwJVUzETMBEGA1UECAwKV2FzaGluZ3RvbjEQMA4GA1UEBwwHU2VhdHRsZTEPMA0GA1UECgwGQW1hem9uMQwwCgYDVQQLDANBV1MxOTA3BgNVBAMMMGktMGJiZjFiZmUyMzJiOGMyY2UudXMtZWFzdC0xLmF3cy5uaXRyby1lbmNsYXZlczB2MBAGByqGSM49AgEGBSuBBAAiA2IABF7SGcHdkRbzl/tGMXHBgJ88sy+HTekW+lomScVSEXYB1giAC6eQgElex/q78JTxuj/k7BV83GfjKE5BS5Bdlohfb3b/yA52MLQubQGAYLSZhBGZmRBaEleTF6r0381CgqNmMGQwEgYDVR0TAQH/BAgwBgEB/wIBADAOBgNVHQ8BAf8EBAMCAgQwHQYDVR0OBBYEFBvZFAgI1uf1KLtxVdsv0Zeh+HFMMB8GA1UdIwQYMBaAFFRGyCn8tZshs/IN+qolNuLZ48fmMAoGCCqGSM49BAMDA2kAMGYCMQDWFeTovh3hlMUu+/nEXCCTKs/0NftxY2s+BXSNFUki8V+LAYNeARuv2FpWHIWR9EECMQCNqJQe507gy1zFEy6loraps1Ohbz9rVETmbRvqekvcYb0KCq9uJMeKaWzgnWWD0wI=";
+    // let issuer_der = STANDARD.decode(issuer_pem).expect("Failed to decode PEM");
+    // let issuer_cert =
+    //     x509_cert::Certificate::from_der(&issuer_der).expect("decode x509 cert failed");
 
     let issuer_public_key = issuer_cert
         .tbs_certificate
@@ -73,11 +71,11 @@ pub fn verify(
     //TODO: should panic if algorithm is not expected
 
     //TEST: print to PEM for testing in web decoder
-    let cert_base64 = encode(&issuer_der);
-    println!(
-        "-----BEGIN CERTIFICATE-----\n{}\n-----END CERTIFICATE-----",
-        cert_base64
-    );
+    // let cert_base64 = encode(&issuer_der);
+    // println!(
+    //     "-----BEGIN CERTIFICATE-----\n{}\n-----END CERTIFICATE-----",
+    //     cert_base64
+    // );
 
     let issuer_public_key = &issuer_public_key[issuer_public_key.len() - 97..];
     let issuer_public_key =
@@ -127,16 +125,14 @@ pub fn verify(
         .to_der()
         .expect("Failed to get TBS certificate raw bytes");
 
-    let pub_key = x509_cert.public_key().expect("Failed to get public key");
+    // let pub_key = x509_cert.public_key().expect("Failed to get public key");
     //println!("subject public key: {:?}", pub_key);
     println!("x509 signature: {:?}", x509_cert.signature().as_slice());
     println!("sig_structure_x509: {:?}", tbs_cert);
 
     ///// get public key from issuer_cert
-    let issuer_cert =
-        openssl::x509::X509::from_der(&issuer_der).expect("Failed to parse issuer PEM");
-
-    use base64::encode;
+    // let issuer_cert =
+    //     openssl::x509::X509::from_der(&issuer_der).expect("Failed to parse issuer PEM");
 
     //////////////////////////////////////////////////////////////////////////////
     //OK: 2.verify remote attestation document signature
@@ -477,22 +473,21 @@ fn extract_certificates_from_der(der_bundle: &[u8]) -> Vec<Certificate> {
     let mut offset = 0;
 
     while offset < der_bundle.len() {
-        // Attempt to parse a certificate from the current offset
         let mut temp_offset = offset;
         while temp_offset < der_bundle.len() {
-            match Certificate::from_der(&der_bundle[temp_offset..]) {
+            match Certificate::from_der(&der_bundle[offset..temp_offset]) {
                 Ok(cert) => {
                     certificates.push(cert.clone());
-                    println!("found a cert at {:?} {:?}", offset, temp_offset);
-                    // Move the offset by the length of the DER-encoded certificate
-                    offset = temp_offset + cert.to_der().expect("Failed to convert certificate to DER").len();
-                    break; // Exit the inner loop to continue with the next certificate
+                    offset = temp_offset;
+                    break;
                 }
                 Err(_) => {
-                    // If parsing fails, increase the offset by 1 to try the next position
                     temp_offset += 1;
                 }
             }
+        }
+        if temp_offset == der_bundle.len() {
+            offset += 1;
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,9 +41,11 @@ pub fn verify(
     //OK: algorithm is ECDSA using SHA384
     // println!("signature_algorithm: {:?}", cert.signature_algorithm);
     //println!("subject_public_key_info: {:?}", cert.tbs_certificate.issuer);
-    //TODO: next step: extract issuer signature cabundle object iof hardcoded
-    //TODO: panic if algorithm is not expected
 
+    //NOTE: we need from certificate: signature & sig_structure = certificate itself (?)
+
+    //NOTE: issuer cert is extracted from the cabundle (check main branch to find the code to extract the certs from cabundle object)
+    //TODO: next step: extract issuer signature cabundle object iof hardcoded
     let issuer_pem = "MIICvzCCAkSgAwIBAgIUXfCzGrCNSNDTS+L1DQQA9CBMKNwwCgYIKoZIzj0EAwMwgYkxPDA6BgNVBAMMM2Y3NWZiMzQ0NzZhOTJhODcuem9uYWwudXMtZWFzdC0xLmF3cy5uaXRyby1lbmNsYXZlczEMMAoGA1UECwwDQVdTMQ8wDQYDVQQKDAZBbWF6b24xCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJXQTEQMA4GA1UEBwwHU2VhdHRsZTAeFw0yNDA5MTMxNDIzNTBaFw0yNDA5MTQxNDIzNTBaMIGOMQswCQYDVQQGEwJVUzETMBEGA1UECAwKV2FzaGluZ3RvbjEQMA4GA1UEBwwHU2VhdHRsZTEPMA0GA1UECgwGQW1hem9uMQwwCgYDVQQLDANBV1MxOTA3BgNVBAMMMGktMGJiZjFiZmUyMzJiOGMyY2UudXMtZWFzdC0xLmF3cy5uaXRyby1lbmNsYXZlczB2MBAGByqGSM49AgEGBSuBBAAiA2IABF7SGcHdkRbzl/tGMXHBgJ88sy+HTekW+lomScVSEXYB1giAC6eQgElex/q78JTxuj/k7BV83GfjKE5BS5Bdlohfb3b/yA52MLQubQGAYLSZhBGZmRBaEleTF6r0381CgqNmMGQwEgYDVR0TAQH/BAgwBgEB/wIBADAOBgNVHQ8BAf8EBAMCAgQwHQYDVR0OBBYEFBvZFAgI1uf1KLtxVdsv0Zeh+HFMMB8GA1UdIwQYMBaAFFRGyCn8tZshs/IN+qolNuLZ48fmMAoGCCqGSM49BAMDA2kAMGYCMQDWFeTovh3hlMUu+/nEXCCTKs/0NftxY2s+BXSNFUki8V+LAYNeARuv2FpWHIWR9EECMQCNqJQe507gy1zFEy6loraps1Ohbz9rVETmbRvqekvcYb0KCq9uJMeKaWzgnWWD0wI=";
     let issuer_der = STANDARD.decode(issuer_pem).expect("Failed to decode PEM");
     let issuer_cert =
@@ -61,6 +63,7 @@ pub fn verify(
     // );
     // println!("cert name {:?}", cert.tbs_certificate.subject.to_string());
     // println!("cert algorithm: {:?}", cert.signature_algorithm);
+    //TODO: should panic if algorithm is not expected
 
     //TEST: print to PEM for testing in web decoder
     let cert_base64 = encode(&issuer_der);
@@ -68,9 +71,8 @@ pub fn verify(
         "-----BEGIN CERTIFICATE-----\n{}\n-----END CERTIFICATE-----",
         cert_base64
     );
-    //OK:
-    let issuer_public_key = &issuer_public_key[issuer_public_key.len() - 97..];
 
+    let issuer_public_key = &issuer_public_key[issuer_public_key.len() - 97..];
     let issuer_public_key =
         VerifyingKey::from_sec1_bytes(&issuer_public_key).expect("Invalid public key");
 
@@ -78,7 +80,7 @@ pub fn verify(
     //TODO: should be issuer sig & issuer sig_structure
     let x509_signature = cert.signature.raw_bytes();
 
-    //remove DER header
+    //@ok remove DER header, rest is the same as openssl
     let x509_signature: [u8; 96] = x509_signature[cert.signature.raw_bytes().len() - 96..]
         .try_into()
         .expect("x509 signature doesn't have enough bytes");
@@ -98,7 +100,7 @@ pub fn verify(
     // sig_structure_x509_with_prefix.extend_from_slice(&sig_structure_x509);
     // let sig_structure_x509 = sig_structure_x509_with_prefix;
 
-    //BUG:  verify fails here
+    //BUG:  verify fails here, one of 3 values must be wrong
     issuer_public_key
         .verify(&cert_vec, &x509_signature)
         .expect("verify x509 cert failed");
@@ -132,7 +134,7 @@ pub fn verify(
     use base64::encode;
 
     //////////////////////////////////////////////////////////////////////////////
-    // 2.verify remote attestation document signature
+    //OK: 2.verify remote attestation document signature
     //this public key is different than the one that signed the x509
     //note:sec1 doesnt comprise der headers
     let public_key = cert


### PR DESCRIPTION
use x509_cert instead of using openssl
need to parse signature, certificate from certificate bytes  of remote attestation
then issuer pubkey from issuer certificate
then verify signature using all 3

run test_verify()  test to see the failing test